### PR TITLE
I18N Issues

### DIFF
--- a/image_so.php
+++ b/image_so.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Image Source Overlay
  * Plugin URI:
- * Text Domain: image_so
+ * Text Domain: image-source-overlay
  * Description: Adds overlay with image sources.
  * Version: 1.0.1
  * Author: Eduard Stehlík

--- a/inc/admin/class.image_so_admin.php
+++ b/inc/admin/class.image_so_admin.php
@@ -43,7 +43,7 @@ final class Image_SO_Admin extends Image_SO_Base
      * @brief Adds plugin admin page to Wordpress menu.
      */
     public function admin_menu() {
-        add_management_page(__('Image SO Settings', 'image_so'), __('Image SO Settings', 'image_so'), 'manage_options', 'image_so', array($this, 'admin_page'));
+        add_management_page(__('Image SO Settings', 'image-source-overlay'), __('Image SO Settings', 'image-source-overlay'), 'manage_options', 'image_so', array($this, 'admin_page'));
     }
 
     /**
@@ -56,7 +56,7 @@ final class Image_SO_Admin extends Image_SO_Base
         }
         else {
             ?>
-            <p> <?php __("You are not authorized to perform this operation.", 'image_so') ?> </p>
+            <p> <?php __("You are not authorized to perform this operation.", 'image-source-overlay') ?> </p>
             <?php
         }
     }
@@ -68,7 +68,7 @@ final class Image_SO_Admin extends Image_SO_Base
         if (isset($_REQUEST['image_so_admin_notice'])) {
             if($_REQUEST['image_so_admin_notice'] === "success") {
                 $html =	'<div class="notice notice-success is-dismissible"> 
-							<p><strong>' . __('Success') . ' </strong>';
+							<p><strong>' . __('Success', 'image-source-overlay') . ' </strong>';
                 $html .= sanitize_text_field(print_r($_REQUEST['image_so_response'], true)) . '</p></div>';
                 echo wp_kses_post($html);
             }
@@ -83,14 +83,14 @@ final class Image_SO_Admin extends Image_SO_Base
             $source_text = sanitize_text_field($_POST['image_so-source-text']);
             $position = sanitize_text_field($_POST['image_so-position']);
             if (!$this->check_select($position, array('top-left', 'top-right', 'bottom-left', 'bottom-right'))) {
-                wp_die(__( 'Invalid option', 'image_so'), __('Error'), array(
+                wp_die(__( 'Invalid option', 'image-source-overlay'), __('Error', 'image-source-overlay'), array(
                     'response' 	=> 403,
                     'back_link' => 'admin.php?page=image_so',
                 ));
             }
             $only_post = sanitize_text_field($_POST['image_so-only-post']);
             if (!$this->check_select($only_post, array('0', '1'))) {
-                wp_die(__( 'Invalid option', 'image_so'), __('Error'), array(
+                wp_die(__( 'Invalid option', 'image-source-overlay'), __('Error', 'image-source-overlay'), array(
                     'response' 	=> 403,
                     'back_link' => 'admin.php?page=image_so',
                 ));
@@ -99,11 +99,11 @@ final class Image_SO_Admin extends Image_SO_Base
             $this->update_option_value('position', $position);
             $this->update_option_value('only_post', $only_post);
             $admin_notice = "success";
-            $this->custom_redirect($admin_notice, 'image_so', __('settings were saved.', 'image_so'));
+            $this->custom_redirect($admin_notice, 'image_so', __('settings were saved.', 'image-source-overlay'));
             exit;
         }
         else {
-            wp_die(__( 'Invalid nonce specified', 'image_so'), __('Error'), array(
+            wp_die(__( 'Invalid nonce specified', 'image-source-overlay'), __('Error', 'image-source-overlay'), array(
                 'response' 	=> 403,
                 'back_link' => 'admin.php?page=image_so',
             ));
@@ -121,8 +121,8 @@ final class Image_SO_Admin extends Image_SO_Base
 
         $form_fields['image_so_source_name'] = array(
             'value' => $field_value ? esc_attr($field_value) : '',
-            'label' => __('Source name', 'image_so'),
-            'helps' => __('Include the source name', 'image_so'),
+            'label' => __('Source name', 'image-source-overlay'),
+            'helps' => __('Include the source name', 'image-source-overlay'),
             'input'  => 'text'
         );
 
@@ -130,23 +130,23 @@ final class Image_SO_Admin extends Image_SO_Base
 
         $form_fields['image_so_source_url'] = array(
             'value' => $field_value ? esc_attr($field_value) : '',
-            'label' => __('Source URL', 'image_so'),
-            'helps' => __('URL to link the source to', 'image_so'),
+            'label' => __('Source URL', 'image-source-overlay'),
+            'helps' => __('URL to link the source to', 'image-source-overlay'),
             'input'  => 'url'
         );
 
         $field_value = get_post_meta($post->ID, 'image_so_source_position', true);
         $form_fields['image_so_source_position'] = array(
-            'label' => __('Source position', 'image_so'),
-            'helps' => __('Where the source will be positioned', 'image_so'),
+            'label' => __('Source position', 'image-source-overlay'),
+            'helps' => __('Where the source will be positioned', 'image-source-overlay'),
             'input' => 'html'
         );
         $form_fields['image_so_source_position']['html'] = "<select name='attachments[{$post->ID}][image_so_source_position]'>";
-        $form_fields['image_so_source_position']['html'] .= '<option '.selected($field_value, 'default',false).' value="default">' . __('Default', 'image_so') . '</option>';
-        $form_fields['image_so_source_position']['html'] .= '<option '.selected($field_value, 'top-left',false).' value="top-left">' . __('Top left', 'image_so') . '</option>';
-        $form_fields['image_so_source_position']['html'] .= '<option '.selected($field_value, 'top-right',false).' value="top-right">' . __('Top right', 'image_so') . '</option>';
-        $form_fields['image_so_source_position']['html'] .= '<option '.selected($field_value, 'bottom-left',false).' value="bottom-left">' . __('Bottom left', 'image_so') . '</option>';
-        $form_fields['image_so_source_position']['html'] .= '<option '.selected($field_value, 'bottom-right',false).' value="bottom-right">' . __('Bottom right', 'image_so') . '</option>';
+        $form_fields['image_so_source_position']['html'] .= '<option '.selected($field_value, 'default',false).' value="default">' . __('Default', 'image-source-overlay') . '</option>';
+        $form_fields['image_so_source_position']['html'] .= '<option '.selected($field_value, 'top-left',false).' value="top-left">' . __('Top left', 'image-source-overlay') . '</option>';
+        $form_fields['image_so_source_position']['html'] .= '<option '.selected($field_value, 'top-right',false).' value="top-right">' . __('Top right', 'image-source-overlay') . '</option>';
+        $form_fields['image_so_source_position']['html'] .= '<option '.selected($field_value, 'bottom-left',false).' value="bottom-left">' . __('Bottom left', 'image-source-overlay') . '</option>';
+        $form_fields['image_so_source_position']['html'] .= '<option '.selected($field_value, 'bottom-right',false).' value="bottom-right">' . __('Bottom right', 'image-source-overlay') . '</option>';
         $form_fields['image_so_source_position']['html'] .= '</select>';
 
         return $form_fields;
@@ -168,7 +168,7 @@ final class Image_SO_Admin extends Image_SO_Base
         if (isset($_REQUEST['attachments'][$attachment_id]['image_so_source_position'])) {
             $image_so_source_position = sanitize_text_field($_REQUEST['attachments'][$attachment_id]['image_so_source_position']);
             if (!$this->check_select($image_so_source_position, array('default', 'top-left', 'top-right', 'bottom-left', 'bottom-right'))) {
-                wp_die(__( 'Invalid option', 'image_so'), __('Error'), array(
+                wp_die(__( 'Invalid option', 'image-source-overlay'), __('Error', 'image-source-overlay'), array(
                     'response' 	=> 403,
                     'back_link' => 'admin.php?page=image_so',
                 ));
@@ -193,6 +193,6 @@ final class Image_SO_Admin extends Image_SO_Base
      */
     private function get_settings_link()
     {
-        return  '<a href="' . esc_url(admin_url('admin.php?page=image_so')) . '">' . __('Settings') . '</a>';
+        return  '<a href="' . esc_url(admin_url('admin.php?page=image_so')) . '">' . __('Settings', 'image-source-overlay') . '</a>';
     }
 }

--- a/inc/admin/views/admin_page.php
+++ b/inc/admin/views/admin_page.php
@@ -7,7 +7,7 @@ Datum: 09.09.2022
 */
 ?>
 <div class="wrap">
-    <h1 class="wp-heading-inline"><?php _e('Image Source Overlay Settings', 'image_so'); ?></h1>
+    <h1 class="wp-heading-inline"><?php _e('Image Source Overlay Settings', 'image-source-overlay'); ?></h1>
     <div class="image_so_admin_form">
         <form action="<?php echo(esc_url(admin_url( 'admin-post.php' ))); ?>" method="post" id="image_so_admin_form" >
             <input type="hidden" name="action" value="image_so_admin_form_response">
@@ -16,41 +16,41 @@ Datum: 09.09.2022
                 <tbody>
                 <tr>
                     <th scope="row">
-                        <label for="image_so-source-text"><?php _e('Source text', 'image_so'); ?></label>
+                        <label for="image_so-source-text"><?php _e('Source text', 'image-source-overlay'); ?></label>
                     </th>
                     <td>
-                        <input id="image_so-source-text" type="text" name="image_so-source-text" value="<?php echo(esc_attr($source_text)); ?>" placeholder="<?php _e('Source:', 'image_so'); ?>" />
-                        <p class="description" id="tagline-source-text"><?php _e('Leave blank for default plugin translation.', 'image_so'); ?></p>
+                        <input id="image_so-source-text" type="text" name="image_so-source-text" value="<?php echo(esc_attr($source_text)); ?>" placeholder="<?php _e('Source:', 'image-source-overlay'); ?>" />
+                        <p class="description" id="tagline-source-text"><?php _e('Leave blank for default plugin translation.', 'image-source-overlay'); ?></p>
                     </td>
                 </tr>
                 <tr>
                     <th scope="row">
-                        <label for="image_so-position"><?php _e('Position', 'image_so'); ?></label>
+                        <label for="image_so-position"><?php _e('Position', 'image-source-overlay'); ?></label>
                     </th>
                     <td>
                         <select required id="image_so-position" name="image_so-position" />
-                            <option <?php if($position === 'top-left') echo('selected'); ?> value="top-left"><?php _e('Top left', 'image_so'); ?></option>
-                            <option <?php if($position === 'top-right') echo('selected'); ?> value="top-right"><?php _e('Top right', 'image_so'); ?></option>
-                            <option <?php if($position === 'bottom-left') echo('selected'); ?> value="bottom-left"><?php _e('Botom left', 'image_so'); ?></option>
-                            <option <?php if($position === 'bottom-right') echo('selected'); ?> value="bottom-right"><?php _e('Botom right', 'image_so'); ?></option>
+                            <option <?php if($position === 'top-left') echo('selected'); ?> value="top-left"><?php _e('Top left', 'image-source-overlay'); ?></option>
+                            <option <?php if($position === 'top-right') echo('selected'); ?> value="top-right"><?php _e('Top right', 'image-source-overlay'); ?></option>
+                            <option <?php if($position === 'bottom-left') echo('selected'); ?> value="bottom-left"><?php _e('Botom left', 'image-source-overlay'); ?></option>
+                            <option <?php if($position === 'bottom-right') echo('selected'); ?> value="bottom-right"><?php _e('Botom right', 'image-source-overlay'); ?></option>
                         </select>
                     </td>
                 </tr>
                 <tr>
                     <th scope="row">
-                        <label for="image_so-only-post"><?php echo __('Only on post page', 'image_so'); ?></label>
+                        <label for="image_so-only-post"><?php echo __('Only on post page', 'image-source-overlay'); ?></label>
                     </th>
                     <td>
                         <select required id="image_so-only-post" name="image_so-only-post" />
                         <option <?php if($only_post === '0') echo('selected'); ?> value="0"><?php _e('Yes'); ?></option>
                         <option <?php if($only_post === '1') echo('selected'); ?> value="1"><?php _e('No'); ?></option>
                         </select>
-                        <p class="description" id="tagline-only-text"><?php _e('If source overlay should be shown only on post pages or on every page including main page.', 'image_so'); ?></p>
+                        <p class="description" id="tagline-only-text"><?php _e('If source overlay should be shown only on post pages or on every page including main page.', 'image-source-overlay'); ?></p>
                     </td>
                 </tr>
                 </tbody>
             </table>
-            <p class="submit"><input type="submit" name="submit" id="submit" class="button button-primary" value="<?php _e('Save changes'); ?>"></p>
+            <p class="submit"><input type="submit" name="submit" id="submit" class="button button-primary" value="<?php _e('Save changes', 'image-source-overlay'); ?>"></p>
         </form>
         <br/><br/>
         <div id="image_so_form_feedback"></div>

--- a/inc/core/class.image_so_init.php
+++ b/inc/core/class.image_so_init.php
@@ -56,7 +56,7 @@ final class Image_SO_Init extends Image_SO_Base
                         }
                         $source_text = $this->source_text;
                         $source = htmlspecialchars($source);
-                        $overlay->textContent = (!empty($source_text) ? $source_text : (__('Source', 'image_so') . ':')) . ' ';
+                        $overlay->textContent = (!empty($source_text) ? $source_text : (__('Source', 'image-source-overlay') . ':')) . ' ';
                         if (!empty($source_url = get_post_meta($id, 'image_so_source_url', true))) {
                             $url = $doc->createElement('a');
                             $url->setAttribute('href', esc_url($source_url));


### PR DESCRIPTION
- This plugin's slug is `image-source-overlay`, but the current Text Domain is `image_so`. Change the current Text Domain so it is equal to this plugin's slug and modify the text domain in all your source files. This change is **needed**, please refer to [this article](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains).
- If there are strings in your plugin that are also used in WordPress core (e.g. **"Settings"**), you should still add your own text domain to them, otherwise, they’ll become untranslated if the core string changes (which happens).